### PR TITLE
フォルダ機能の作成

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,6 +22,7 @@
 
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*
+!/tmp/pids/
 !/tmp/pids/.keep
 
 # Ignore storage (uploaded files in development and any SQLite databases).

--- a/app/assets/stylesheets/add_btn.scss
+++ b/app/assets/stylesheets/add_btn.scss
@@ -1,0 +1,167 @@
+/* This is an example, feel free to delete this code */
+.tooltip-flame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  // sssss
+  .tooltip-container {
+    background: transparent;
+    background: linear-gradient(
+      138deg,
+      rgb(0, 109, 20) 15%,
+      rgb(30, 116, 40) 65%
+    );
+    position: relative;
+    cursor: pointer;
+    border-radius: 50px;
+    box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.1);
+    color:#fff;
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 42px;
+
+  }
+  .tooltip-container:hover {
+    background: #fff;
+    transition: all 0.6s;
+  }
+
+  .tooltip-container .text {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    transition: all 0.2s;
+  }
+
+  .tooltip-container:hover .text {
+    color: rgb(1, 119, 36);
+    transition: all 0.6s;
+  }
+
+  /* Inicio do tooltip pinterest */
+  .tooltip1 {
+    position: absolute;
+    top: 100%;
+    left: -200%;
+    transform: translateX(70%);
+    opacity: 0;
+    visibility: hidden;
+    background: #fff;
+    color: #eec512;
+    padding: 10px;
+    border-radius: 50px;
+    transition: opacity 0.3s, visibility 0.3s, top 0.3s, background 0.3s;
+    z-index: 1;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    width: 45px;
+    height: 45px;
+    i {
+      position: absolute;
+      top: 5%;
+      left: 20%;
+    }
+  }
+
+  .tooltip-container:hover .tooltip1 {
+    top: -78%;
+    opacity: 1;
+    visibility: visible;
+    background: #fff;
+    transform: translate(70%, -5px);
+    border-radius: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .tooltip-container:hover .tooltip1:hover {
+    background: #eec512;
+    color: #fff;
+  }
+  /* Fim do tooltip pinterest */
+
+  /* Inicio do tooltip dribbble */
+  .tooltip2 {
+    position: absolute;
+    top: 100%;
+    left: 35%;
+    transform: translateX(70%);
+    opacity: 0;
+    visibility: hidden;
+    background: #fff;
+    color: #eec512;
+    padding: 10px;
+    border-radius: 50px;
+    transition: opacity 0.3s, visibility 0.3s, top 0.3s, background 0.3s;
+    z-index: 1;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    width: 45px;
+    height: 45px;
+    i {
+      position: absolute;
+      top: 3%;
+      left: 15%;
+    }
+  }
+
+  .tooltip-container:hover .tooltip2 {
+    top: -79%;
+    opacity: 1;
+    visibility: visible;
+    background: #fff;
+    transform: translate(70%, -5px);
+    border-radius: 50px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .tooltip-container:hover .tooltip2:hover {
+    background: #eec512;
+    color: #fff;
+  }
+  /* Fim do tooltip dribbble */
+
+  // /* Inicio do tooltip fixo */
+  // .tooltip9 {
+  //   position: absolute;
+  //   top: 0;
+  //   left: -115%;
+  //   opacity: 0;
+  //   visibility: hidden;
+  //   width: 150px;
+  //   height: 150px;
+  //   z-index: -1;
+  // }
+
+  // .tooltip-container:hover .tooltip9 {
+  //   top: -110%;
+  //   opacity: 1;
+  //   visibility: visible;
+  //   border-radius: 50%;
+  //   z-index: -1;
+  // }
+
+  //仮
+  .tooltip9 {
+    position: absolute;
+    top: 0;
+    left: -115%;
+    opacity: 0;
+    visibility: hidden;
+    z-index: -1;
+    width: 140px;
+    height: 55px;
+  }
+
+  .tooltip-container:hover .tooltip9 {
+    top: -80%;
+    opacity: 1;
+    visibility: visible;
+    border-radius: 60%;
+    z-index: 0;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,4 +16,5 @@
  @import "application.bootstrap";
  @import "top";
  @import "header";
- @import "dashboard";
+ @import "dashboard"; 
+ @import "add_btn"; 

--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -57,6 +57,18 @@
                     flex-direction: row;
                     flex-wrap: wrap; 
 
+                    .link-block {
+                        display: flex;
+                        flex-direction: row;
+                        flex-wrap: wrap;
+                    }
+                
+                    .folder-block {
+                        display: flex;
+                        flex-direction: row;
+                        flex-wrap: wrap;
+                    }
+
                     .item-back {
                         background-color: rgb(255, 255, 255);
                         box-shadow: 0 3px 5px rgba(0, 0, 0, 0.22);
@@ -75,12 +87,18 @@
                                 display: flex;
                                 justify-content: center;
                                 align-items: center;
+                            }
+                        }
 
-                                i {
-                                    // +icon
-                                    color: #e6e6e6;
-                                    font-size: 3rem;
-                                }
+                        &.folder {
+                            background-color: transparent;
+                            box-shadow: 0 0px 0px;
+                            display: flex;
+                            justify-content: center;
+                            align-items: center;
+
+                            .folder-icon {
+                                font-size: 7rem;
                             }
                         }
 
@@ -91,7 +109,6 @@
                                 width: 100%;
                                 height: 100%;
                             }
-                
                 
                             .link-title {
                                 font-size: 1.25rem;
@@ -111,5 +128,16 @@
     .category-link {
         text-decoration: none;
         color:rgba(64, 64, 64)
+    }
+
+    .folder-frame {
+        display: flex;
+        justify-content: flex-end;
+
+        .folder-back {
+            background-color: rgb(134, 146, 138);
+            width:90%;
+            border-radius: 10px;
+        }
     }
 }

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -4,6 +4,10 @@ class DashboardsController < ApplicationController
     @home_layouts = current_user.home_layouts.order(position: :asc)
     @home_layouts.each do |layout|
       layout.categories = layout.categories.order(position: :asc)
+
+      layout.categories.each do |category|
+        category.folders = category.folders.order(position: :asc)
+      end
     end
   end
 end

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -1,0 +1,49 @@
+class FoldersController < ApplicationController
+  before_action :require_login
+
+  def new
+    @folder = Folder.new
+    @category_id = params[:category_id]
+  end
+
+  def create
+    @folder = Folder.new(folder_params)
+    @folder.user_id = current_user.id
+    @folder.position = Folder.get_new_position_folder(@folder.category_id)
+
+    return if @folder.save
+
+    render :new, status: :unprocessable_entity
+  end
+
+  def edit
+    set_folder
+    @category_id = @folder.category_id
+  end
+
+  def update
+    set_folder
+    return if @folder.update(folder_params)
+
+    render :edit, status: :unprocessable_entity
+  end
+
+  def destroy
+    set_folder
+    @folder.destroy!
+  end
+
+  def show
+    @folder = Folder.new
+  end
+
+  private
+
+  def set_folder
+    @folder = Folder.find(params[:id])
+  end
+
+  def folder_params
+    params.require(:folder).permit(:name, :description, :category_id)
+  end
+end

--- a/app/javascript/controllers/folder_controller.js
+++ b/app/javascript/controllers/folder_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+import { Modal } from "bootstrap"
+
+// Connects to data-controller="folder"
+export default class extends Controller {
+  connect() {
+    console.log("category open") 
+    this.modal = new Modal(this.element)
+    this.modal.show()
+  }
+
+  disconnect() {
+    // 問題が起きる可能性があるので念のためモーダルを廃棄する
+    this.modal.dispose();
+  }
+
+  close(event) {
+    console.log("close_login")
+    if (event.detail.success) {
+      this.modal.hide()
+    }
+  }
+
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -15,3 +15,6 @@ application.register("login_modal", LoginModalController)
 
 import CategoryController from "./category_controller"
 application.register("category", CategoryController)
+
+import FolderController from "./folder_controller"
+application.register("folder", FolderController)

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -28,6 +28,7 @@ class Category < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :group, optional: true
   has_many :home_layouts, foreign_key: :user_id, primary_key: :user_id
+  has_many :folders, dependent: :destroy
 
   validates :name, presence: true
   validates :position, presence: true
@@ -42,7 +43,7 @@ class Category < ApplicationRecord
       user_id:,
       group_id: nil,
       name: 'uncategorized',
-      position: get_max_position_for_user(user_id),
+      position: get_new_position_for_user(user_id),
       is_uncategorized: true
     )
   end

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -1,0 +1,48 @@
+# == Schema Information
+#
+# Table name: folders
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  position    :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint           not null
+#  group_id    :bigint
+#  parent_id   :bigint
+#  user_id     :bigint
+#
+# Indexes
+#
+#  index_folders_on_category_id  (category_id)
+#  index_folders_on_group_id     (group_id)
+#  index_folders_on_parent_id    (parent_id)
+#  index_folders_on_user_id      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (category_id => categories.id)
+#  fk_rails_...  (group_id => groups.id)
+#  fk_rails_...  (parent_id => folders.id)
+#  fk_rails_...  (user_id => users.id)
+#
+class Folder < ApplicationRecord
+  belongs_to :category
+  belongs_to :group, optional: true
+  belongs_to :user, optional: true
+  # 親フォルダーは同じ Folder クラスの他のフォルダ
+  belongs_to :parent, class_name: 'Folder', optional: true
+  # parent_id カラムが folders テーブルの id カラムを参照する
+  has_many :subfolders, class_name: 'Folder', foreign_key: 'parent_id', dependent: :destroy
+
+  validates :name, presence: true
+  validates :position, presence: true
+
+  # ---------------------
+  # folderの配置位置を取得
+  # ---------------------
+  def self.get_new_position_folder(category_id)
+    where(category_id:).maximum(:position).to_i + 1
+  end
+end

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -11,30 +11,39 @@
                 <% end %>
 
                 <%# 削除リンク %>
-                <%= link_to category_path(category), data: {turbo_method: :delete, turbo_confirm: t('confirm.delete', title: t('category.title'))}, class: "category-link" do %>
+                <%= link_to(category_path(category), data: {turbo_method: :delete, turbo_confirm: t('confirm.delete', title: t('category.title'))}, class: "category-link") do %>
                     <span><i class="bi bi-trash-fill"></i></span>
                 <% end %>
             </div>
         <% end %>
-
     </div> 
+
     <%# ダミーアイテム %>
     <div class="content">
-        <div class="item-back">
-            <div class="item-contents">
-                <div class="image-container">
-                    <%= image_tag("sample.jpg", class: "link-image") %>
+        <div id="link-block-<%= category.id %>" class="link-block">
+            <div class="item-back">
+                <div class="item-contents">
+                    <div class="image-container">
+                        <%= image_tag("sample.jpg", class: "link-image") %>
+                    </div>
+                    <div class="link-title text-start">ダミーTitle</div>
+                    <div class="link-desc text-start ">ダミーDescription</div>
                 </div>
-                <div class="link-title text-start">ダミーTitle</div>
-                <div class="link-desc text-start ">ダミーDescription</div>
             </div>
         </div>
 
-        <%# +ボタン(要素) %>
-        <div class="item-back add">
-            <div class="add-button">
-                <i class="bi bi-plus-circle-fill"></i>
-            </div>
+        <%# フォルダパーシャル %>
+        <div id="folder-block-<%= category.id %>" class="folder-block">
+            <%= render partial: "folders/folder", locals: { category: category }, collection: category.folders %>
         </div>
+
+        <%# カテゴリADDボタン %>
+        <%= render "shared/add_button", category: category, folder_id: nil %>
+    </div>
+
+    <%# accordion block %>
+    <div id="category-accordion-<%= category.id %>" class="accordion">
+        <%# folder content %>
+        <%= render partial: "folders/folder_panel", locals: { category: category }, collection: category.folders, as: :folder %>
     </div>
 </div>

--- a/app/views/folders/_folder.html.erb
+++ b/app/views/folders/_folder.html.erb
@@ -1,0 +1,27 @@
+    <div id="folder_<%= folder.id %>" class="item-back folder">
+        <div class="item-contents" data-controller="accordion">
+            <div >
+                <button class="accordion-button mb-n3" type="button" data-bs-toggle="collapse"
+                        data-bs-target="#folder-panel-<%= folder.id %>" aria-expanded="true"
+                        aria-controls="folder-panel-<%= folder.id %>"
+                        style="display:block; text-align:center; margin-bottom: -30px;">
+                        <i class="bi bi-folder-fill folder-icon"></i>
+                </button>
+            </div> 
+            <div class="text-center" style="overflow-wrap: anywhere;">
+                <div class="folder-title">
+                    <%= folder.name %>
+                </div>
+
+                <div class="folder-link text-center mt-2">
+                    <%= link_to(edit_folder_path(folder, category_id: folder.category_id), data: { turbo_frame: 'folder_modal' }, class: "category-link") do %>
+                        <i class="bi bi-pencil-fill me-1"></i>
+                    <% end %>
+
+                    <%= link_to(folder_path(folder), data: {turbo_method: :delete, turbo_confirm: t('confirm.delete', title: t('folder.title'))}, class: "category-link") do %>
+                        <i class="bi bi-trash-fill"></i>
+                    <% end %>
+                </div>
+            </div> 
+        </div>
+    </div>

--- a/app/views/folders/_folder_modal_base.html.erb
+++ b/app/views/folders/_folder_modal_base.html.erb
@@ -1,0 +1,20 @@
+<%= turbo_frame_tag 'folder_modal' do %>
+<div class="modal fade" id="folderModal" data-controller="folder">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content rounded-3">
+
+      <div class="modal-body">  
+        <div class="text-end">
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" data-action="turbo:submit-end->folder#close"></button>
+        </div>
+        <div class="text-center mb-4">
+          <h1 class="modal-title fs-2 fw-semibold" id="staticBackdropLabel"><%= t('folder.title') %></h1>
+        </div>
+
+        <%= render "form" %>
+
+      </div>
+    </div>
+  </div>
+</div>
+<% end %>

--- a/app/views/folders/_folder_panel.html.erb
+++ b/app/views/folders/_folder_panel.html.erb
@@ -1,0 +1,12 @@
+    <div id="folder-panel-<%= folder.id %>" class="accordion-collapse collapse"
+            data-bs-parent="#category-accordion-<%= category.id %>">
+            <div class="folder-frame">
+                <%# フォルダ要素 %>
+                <div class="folder-back" style="">
+                    <div class="content">
+                        <%# +ボタン(要素) %>
+                        <%= render "shared/add_button", category: category, folder_id: folder.id %>
+                    </div>
+                </div>
+            </div>
+    </div>

--- a/app/views/folders/_form.html.erb
+++ b/app/views/folders/_form.html.erb
@@ -1,0 +1,19 @@
+<%= turbo_frame_tag dom_id(@folder, :form) do %>
+    <%= render 'shared/modal_errors', modal_errors: @folder %>
+    <%= form_with model: @folder, html: { data: {action: 'turbo:submit-end->folder#close'}} do |f| %>
+        <div class="w-75 mx-auto mb-5">
+            <div class="mb-3">
+                <%= f.label :name, class: "form-label" %>
+                <%= f.text_field :name, class: "form-control", placeholder: t('folder.placeholder.name') %>
+            </div >
+            <div class="mb-4">
+                <%= f.label :description, class: "form-label" %>
+                <%= f.text_field :description, class: "form-control", placeholder: t('folder.placeholder.description') %>
+            </div >
+            <div class="mt-4">
+                <%= f.submit t('submit.regist'), id: "modal-category-btn", class: "btn btn-success w-100 rounded-3" %>
+            </div >
+            <%= f.hidden_field :category_id, value: @category_id %>
+        </div>
+    <% end %>
+<% end %>

--- a/app/views/folders/create.turbo_stream.erb
+++ b/app/views/folders/create.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.append "folder-block-#{@folder.category_id}", partial: 'folders/folder', locals: { folder: @folder } %>
+<%= turbo_stream.append "category-accordion-#{@folder.category_id}", partial: 'folders/folder_panel', locals: {category: @folder.category, folder: @folder } %>

--- a/app/views/folders/destroy.turbo_stream.erb
+++ b/app/views/folders/destroy.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= turbo_stream.remove "folder_#{@folder.id}" %>
+<%= turbo_stream.remove "folder-panel-#{@folder.id}" %>

--- a/app/views/folders/edit.html.erb
+++ b/app/views/folders/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'folder_modal_base' %>

--- a/app/views/folders/new.html.erb
+++ b/app/views/folders/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'folder_modal_base' %>

--- a/app/views/folders/update.turbo_stream.erb
+++ b/app/views/folders/update.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace "folder_#{@folder.id}", partial: 'folders/folder', locals: { folder: @folder } %>

--- a/app/views/shared/_add_button.html.erb
+++ b/app/views/shared/_add_button.html.erb
@@ -1,0 +1,16 @@
+        <%# +ボタン(要素) %>
+        <div class="item-back add">
+                <%# <i class="bi bi-plus-circle-fill"></i> %>
+            <div class="tooltip-flame add-button">
+                <div class="tooltip-container">
+                    <span class="text"><i class="bi bi-plus-circle-fill"></i></span>
+                    <% unless folder_id.present? %>
+                        <%= link_to(new_folder_path(category_id: category.id), data: { turbo_frame: 'folder_modal' }, class: "folder-link") do %>
+                            <span class="tooltip1"><i class="bi bi-folder2 fs-3"></i></span>
+                        <% end %>
+                    <% end %>
+                    <span class="tooltip2"><i class="bi bi-link-45deg fs-2"></i></span>
+                    <span class="tooltip9" ></span>
+                </div>
+            </div>
+        </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -9,4 +9,6 @@ ja:
       category:
         name: "カテゴリ名"
         description: "概要"
-        
+      folder:
+        name: "フォルダ名"
+        description: "概要" 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -27,7 +27,11 @@ ja:
     placeholder: 
       name: "カテゴリ名"
       description: "概要"
-    confirm: "削除しますか？"
     other:
       uncategorized: "未分類"
+  folder:
+    title: "フォルダ"
+    placeholder:
+      name: "フォルダ名"
+      description: "概要"
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   resources :user_sessions, only: %i[new create destroy]
   resources :dashboards, only: %i[index]
   resources :categories, only: %i[new edit create update destroy]
+  resources :folders, only: %i[new edit create update destroy]
   get 'login', to: 'user_sessions#new'
   post 'login', to: 'user_sessions#create'
   delete 'logout', to: 'user_sessions#destroy'

--- a/db/migrate/20240704122945_create_folders.rb
+++ b/db/migrate/20240704122945_create_folders.rb
@@ -1,0 +1,14 @@
+class CreateFolders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :folders do |t|
+      t.string :name, null: false
+      t.references :parent, foreign_key: { to_table: :folders }, null: true
+      t.references :category, foreign_key: true, null: false
+      t.references :group, foreign_key: true, null: true
+      t.references :user, foreign_key: true, null: true
+      t.integer :position, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240705110648_add_column_folders.rb
+++ b/db/migrate/20240705110648_add_column_folders.rb
@@ -1,0 +1,5 @@
+class AddColumnFolders < ActiveRecord::Migration[7.1]
+  def change
+    add_column :folders, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_04_022128) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_05_110648) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_022128) do
     t.index ["group_id"], name: "index_categories_on_group_id"
     t.index ["user_id", "is_uncategorized"], name: "index_categories_on_user_id_and_is_uncategorized", unique: true, where: "(is_uncategorized = true)"
     t.index ["user_id"], name: "index_categories_on_user_id"
+  end
+
+  create_table "folders", force: :cascade do |t|
+    t.string "name", null: false
+    t.bigint "parent_id"
+    t.bigint "category_id", null: false
+    t.bigint "group_id"
+    t.bigint "user_id"
+    t.integer "position", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "description"
+    t.index ["category_id"], name: "index_folders_on_category_id"
+    t.index ["group_id"], name: "index_folders_on_group_id"
+    t.index ["parent_id"], name: "index_folders_on_parent_id"
+    t.index ["user_id"], name: "index_folders_on_user_id"
   end
 
   create_table "groups", force: :cascade do |t|
@@ -73,6 +89,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_04_022128) do
 
   add_foreign_key "categories", "groups"
   add_foreign_key "categories", "users"
+  add_foreign_key "folders", "categories"
+  add_foreign_key "folders", "folders", column: "parent_id"
+  add_foreign_key "folders", "groups"
+  add_foreign_key "folders", "users"
   add_foreign_key "home_layouts", "groups"
   add_foreign_key "home_layouts", "users"
   add_foreign_key "user_groups", "groups"

--- a/fly.toml
+++ b/fly.toml
@@ -21,6 +21,7 @@ console_command = '/rails/bin/rails console'
   processes = ['app']
 
 [[vm]]
+  memory = '512mb'
   size = 'shared-cpu-1x'
 
 [[statics]]

--- a/spec/factories/category.rb
+++ b/spec/factories/category.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+    factory :category do
+  
+      name { "test_folder" }
+      position { 1 }
+      is_uncategorized { false }
+      user
+
+    end
+  
+end

--- a/spec/factories/folder.rb
+++ b/spec/factories/folder.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+    factory :folder do
+        name { "Sample Folder" }
+        description { "This is a sample folder" }
+        position { 1 }
+        category
+        user
+    end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,9 +1,35 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id               :bigint           not null, primary key
+#  description      :text
+#  is_uncategorized :boolean          default(FALSE), not null
+#  name             :string           not null
+#  position         :integer          not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  group_id         :bigint
+#  user_id          :bigint
+#
+# Indexes
+#
+#  index_categories_on_group_id                       (group_id)
+#  index_categories_on_group_id_and_is_uncategorized  (group_id,is_uncategorized) UNIQUE WHERE (is_uncategorized = true)
+#  index_categories_on_user_id                        (user_id)
+#  index_categories_on_user_id_and_is_uncategorized   (user_id,is_uncategorized) UNIQUE WHERE (is_uncategorized = true)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (group_id => groups.id)
+#  fk_rails_...  (user_id => users.id)
+#
 require 'rails_helper'
 RSpec.describe Category, type: :model do
 
     describe 'カテゴリーのバリデーションテスト' do
         let(:user) { create(:user) }
-        let(:category) { Category.new }
+        let(:category) { Category.new } 
     
         context '名前の存在性チェック' do
           it '名前が存在しない場合、無効であること' do
@@ -28,5 +54,5 @@ RSpec.describe Category, type: :model do
             expect(category).to_not be_valid
           end
         end
-      end
+    end
 end

--- a/spec/models/folder_spec.rb
+++ b/spec/models/folder_spec.rb
@@ -1,0 +1,69 @@
+# == Schema Information
+#
+# Table name: folders
+#
+#  id          :bigint           not null, primary key
+#  description :text
+#  name        :string           not null
+#  position    :integer          not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint           not null
+#  group_id    :bigint
+#  parent_id   :bigint
+#  user_id     :bigint
+#
+# Indexes
+#
+#  index_folders_on_category_id  (category_id)
+#  index_folders_on_group_id     (group_id)
+#  index_folders_on_parent_id    (parent_id)
+#  index_folders_on_user_id      (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (category_id => categories.id)
+#  fk_rails_...  (group_id => groups.id)
+#  fk_rails_...  (parent_id => folders.id)
+#  fk_rails_...  (user_id => users.id)
+#
+require 'rails_helper'
+
+RSpec.describe Folder, type: :model do
+  describe 'フォルダのバリデーションテスト' do
+    let(:user) { create(:user) }
+    let(:category) { create(:category, user: user) }
+    let(:folder) { build(:folder, user: user, category: category) }
+
+    context 'データが条件を満たすとき' do
+        it '保存できる' do
+          expect(folder).to be_valid
+        end
+    end
+
+    context 'nameが空のとき' do
+        it 'エラーが発生する' do
+            folder.name = ''
+            expect(folder).not_to be_valid
+            expect(folder.errors.messages[:name]).to include 'を入力してください'
+        end
+    end
+
+    context 'category_idが空のとき' do
+        it 'エラーが発生する' do
+            folder.category_id = nil
+            expect(folder).not_to be_valid
+            expect(folder.errors.messages[:category]).to include 'を入力してください'
+        end
+    end
+
+    context '位置の存在性チェック' do
+        it '位置が存在しない場合、無効であること' do
+            folder.position = nil
+            expect(folder).not_to be_valid
+        end
+    end
+
+  end
+end
+

--- a/spec/requests/folders_spec.rb
+++ b/spec/requests/folders_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Folders", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
■フォルダ機能の実装
　・フォルダ作成、編集、削除機能を実装
　・フォルダの作成、編集はモーダルを表示し行う。
　・フォルダクリック時に、フォルダの属するカテゴリ下部にアコーディオンを表示し、内容物を表示する。
　
　-実装に伴う仕様・作業変更点
　　1.　カテゴリに内包されているため、監理のしやすさのため、フォルダ内のフォルダ作成を不可に変更
　　2.　ドラッグアンドドロップ機能をMVPリリースの機能から除外（本リリース時に実装するものとする）
Closes: #15 