### PR TITLE
カテゴリ更新時の処理修正

### DIFF
--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -1,6 +1,6 @@
 <div id=category_<%= category.id %> class="category mb-3 pb-3">
     <div class="category-header">
-        <div class="category-name-box text-center">
+        <div id="category_name_<%= category.id %>" class="category-name-box text-center">
             <span class="category-name"><%= category.name %></span>
         </div>
         <% unless category.is_uncategorized %>

--- a/app/views/categories/update.turbo_stream.erb
+++ b/app/views/categories/update.turbo_stream.erb
@@ -1,1 +1,6 @@
-<%= turbo_stream.replace "category_#{@category.id}", partial: 'categories/category', locals: { category: @category } %>
+<%# <%= turbo_stream.replace "category_#{@category.id}", partial: 'categories/category', locals: { category: @category } %>
+<%= turbo_stream.replace "category_name_#{@category.id}" do %>
+    <div id="category_name_<%= @category.id %>" class="category-name-box text-center">
+        <span class="category-name"><%= @category.name %></span>
+    </div>
+<% end %>


### PR DESCRIPTION
カテゴリ更新時の障害を検出したため、修正
内容：
　カテゴリ修正時登録済みのブックマークが表示されなくなる。
原因：
　空のカテゴリ要素を置き換えていたため、画面からブックマークが消えていた。
対応：
　更新した項目をreplaceするよう修正。